### PR TITLE
Rewrite incoming parameters from Data to ContiguousBytes

### DIFF
--- a/GoldenKey/CommonCrypto/Digest.swift
+++ b/GoldenKey/CommonCrypto/Digest.swift
@@ -11,10 +11,11 @@ import CommonCrypto.CommonDigest
 
 public protocol Digest {
 
-    /// Updates the digest with another data chunk. This can be called multiple times. Use this method for streaming digests.
-    /// - parameters:
-    ///     - data: Data chunk to digest.
-    func combine(_ data: Data)
+    /// Updates the digest with another data chunk. This can be called multiple times.
+    /// Use this method for streaming digests.
+    ///
+    /// - Parameters: bytes: Data chunk to digest.
+    func combine<T>(_ bytes: T) where T: ContiguousBytes
 
     /// Return the digest of the data passed to the `combine(_:)` method so far.
     func finalize() -> Data
@@ -36,11 +37,10 @@ public final class MD2: Digest {
     /// Combines data to be hashed.
     /// Can be called repeatedly with chunks of the message.
     ///
-    /// - Parameters:
-    ///   - data: data to be combined
-    public func combine(_ data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_MD2_Update(context, buffer.baseAddress, CC_LONG(data.count))
+    /// - Parameters: bytes: Data chunk to digest.
+    public func combine<T>(_ bytes: T) where T: ContiguousBytes {
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_MD2_Update(context, buffer.baseAddress, CC_LONG(buffer.count))
         }
     }
 
@@ -61,12 +61,12 @@ public final class MD2: Digest {
     /// $ openssl MD2 <<< "string_to_be_hashed"
     ///
     /// - Returns: data digest (cryptographic hash) in MD2.
-    public static func hash(_ data: Data) -> Data {
-        var bytes = [UInt8](repeating: 0, count: Int(CC_MD2_DIGEST_LENGTH))
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_MD2(buffer.baseAddress, CC_LONG(buffer.count), &bytes)
+    public static func hash<T>(_ bytes: T) -> Data where T: ContiguousBytes {
+        var result = [UInt8](repeating: 0, count: Int(CC_MD2_DIGEST_LENGTH))
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_MD2(buffer.baseAddress, CC_LONG(buffer.count), &result)
         }
-        return Data(bytes)
+        return Data(result)
     }
 }
 
@@ -86,11 +86,10 @@ public final class MD4: Digest {
     /// Combines data to be hashed.
     /// Can be called repeatedly with chunks of the message.
     ///
-    /// - Parameters:
-    ///   - data: data to be combined
-    public func combine(_ data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_MD4_Update(context, buffer.baseAddress, CC_LONG(data.count))
+    /// - Parameters: bytes: Data chunk to digest.
+    public func combine<T>(_ bytes: T) where T: ContiguousBytes {
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_MD4_Update(context, buffer.baseAddress, CC_LONG(buffer.count))
         }
     }
 
@@ -111,12 +110,12 @@ public final class MD4: Digest {
     /// $ openssl MD4 <<< "string_to_be_hashed"
     ///
     /// - Returns: data digest (cryptographic hash) in MD4.
-    public static func hash(_ data: Data) -> Data {
-        var bytes = [UInt8](repeating: 0, count: Int(CC_MD4_DIGEST_LENGTH))
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_MD4(buffer.baseAddress, CC_LONG(buffer.count), &bytes)
+    public static func hash<T>(_ bytes: T) -> Data where T: ContiguousBytes {
+        var result = [UInt8](repeating: 0, count: Int(CC_MD4_DIGEST_LENGTH))
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_MD4(buffer.baseAddress, CC_LONG(buffer.count), &result)
         }
-        return Data(bytes)
+        return Data(result)
     }
 }
 
@@ -136,11 +135,10 @@ public final class MD5: Digest {
     /// Combines data to be hashed.
     /// Can be called repeatedly with chunks of the message.
     ///
-    /// - Parameters:
-    ///   - data: data to be combined
-    public func combine(_ data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_MD5_Update(context, buffer.baseAddress, CC_LONG(data.count))
+    /// - Parameters: bytes: Data chunk to digest.
+    public func combine<T>(_ bytes: T) where T: ContiguousBytes {
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_MD5_Update(context, buffer.baseAddress, CC_LONG(buffer.count))
         }
     }
 
@@ -161,12 +159,12 @@ public final class MD5: Digest {
     /// $ openssl MD5 <<< "string_to_be_hashed"
     ///
     /// - Returns: data digest (cryptographic hash) in MD5.
-    public static func hash(_ data: Data) -> Data {
-        var bytes = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_MD5(buffer.baseAddress, CC_LONG(buffer.count), &bytes)
+    public static func hash<T>(_ bytes: T) -> Data where T: ContiguousBytes {
+        var result = [UInt8](repeating: 0, count: Int(CC_MD5_DIGEST_LENGTH))
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_MD5(buffer.baseAddress, CC_LONG(buffer.count), &result)
         }
-        return Data(bytes)
+        return Data(result)
     }
 }
 
@@ -186,11 +184,10 @@ public final class SHA1: Digest {
     /// Combines data to be hashed.
     /// Can be called repeatedly with chunks of the message.
     ///
-    /// - Parameters:
-    ///   - data: data to be combined
-    public func combine(_ data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA1_Update(context, buffer.baseAddress, CC_LONG(data.count))
+    /// - Parameters: bytes: Data chunk to digest.
+    public func combine<T>(_ bytes: T) where T: ContiguousBytes {
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA1_Update(context, buffer.baseAddress, CC_LONG(buffer.count))
         }
     }
 
@@ -211,12 +208,12 @@ public final class SHA1: Digest {
     /// $ openssl SHA1 <<< "string_to_be_hashed"
     ///
     /// - Returns: data digest (cryptographic hash) in SHA1.
-    public static func hash(_ data: Data) -> Data {
-        var bytes = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA1(buffer.baseAddress, CC_LONG(buffer.count), &bytes)
+    public static func hash<T>(_ bytes: T) -> Data where T: ContiguousBytes {
+        var result = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA1(buffer.baseAddress, CC_LONG(buffer.count), &result)
         }
-        return Data(bytes)
+        return Data(result)
     }
 }
 
@@ -236,11 +233,10 @@ public final class SHA224: Digest {
     /// Combines data to be hashed.
     /// Can be called repeatedly with chunks of the message.
     ///
-    /// - Parameters:
-    ///   - data: data to be combined
-    public func combine(_ data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA224_Update(context, buffer.baseAddress, CC_LONG(data.count))
+    /// - Parameters: bytes: Data chunk to digest.
+    public func combine<T>(_ bytes: T) where T: ContiguousBytes {
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA224_Update(context, buffer.baseAddress, CC_LONG(buffer.count))
         }
     }
 
@@ -261,12 +257,12 @@ public final class SHA224: Digest {
     /// $ openssl SHA224 <<< "string_to_be_hashed"
     ///
     /// - Returns: data digest (cryptographic hash) in SHA224.
-    public static func hash(_ data: Data) -> Data {
-        var bytes = [UInt8](repeating: 0, count: Int(CC_SHA224_DIGEST_LENGTH))
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA224(buffer.baseAddress, CC_LONG(buffer.count), &bytes)
+    public static func hash<T>(_ bytes: T) -> Data where T: ContiguousBytes {
+        var result = [UInt8](repeating: 0, count: Int(CC_SHA224_DIGEST_LENGTH))
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA224(buffer.baseAddress, CC_LONG(buffer.count), &result)
         }
-        return Data(bytes)
+        return Data(result)
     }
 }
 
@@ -286,11 +282,10 @@ public final class SHA256: Digest {
     /// Combines data to be hashed.
     /// Can be called repeatedly with chunks of the message.
     ///
-    /// - Parameters:
-    ///   - data: data to be combined
-    public func combine(_ data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA256_Update(context, buffer.baseAddress, CC_LONG(data.count))
+    /// - Parameters: bytes: Data chunk to digest.
+    public func combine<T>(_ bytes: T) where T: ContiguousBytes {
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA256_Update(context, buffer.baseAddress, CC_LONG(buffer.count))
         }
     }
 
@@ -311,12 +306,12 @@ public final class SHA256: Digest {
     /// $ openssl SHA256 <<< "string_to_be_hashed"
     ///
     /// - Returns: data digest (cryptographic hash) in SHA256.
-    public static func hash(_ data: Data) -> Data {
-        var bytes = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA256(buffer.baseAddress, CC_LONG(buffer.count), &bytes)
+    public static func hash<T>(_ bytes: T) -> Data where T: ContiguousBytes {
+        var result = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA256(buffer.baseAddress, CC_LONG(buffer.count), &result)
         }
-        return Data(bytes)
+        return Data(result)
     }
 }
 
@@ -336,11 +331,10 @@ public final class SHA384: Digest {
     /// Combines data to be hashed.
     /// Can be called repeatedly with chunks of the message.
     ///
-    /// - Parameters:
-    ///   - data: data to be combined
-    public func combine(_ data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA384_Update(context, buffer.baseAddress, CC_LONG(data.count))
+    /// - Parameters: bytes: Data chunk to digest.
+    public func combine<T>(_ bytes: T) where T: ContiguousBytes {
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA384_Update(context, buffer.baseAddress, CC_LONG(buffer.count))
         }
     }
 
@@ -361,12 +355,12 @@ public final class SHA384: Digest {
     /// $ openssl SHA384 <<< "string_to_be_hashed"
     ///
     /// - Returns: data digest (cryptographic hash) in SHA384.
-    public static func hash(_ data: Data) -> Data {
-        var bytes = [UInt8](repeating: 0, count: Int(CC_SHA384_DIGEST_LENGTH))
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA384(buffer.baseAddress, CC_LONG(buffer.count), &bytes)
+    public static func hash<T>(_ bytes: T) -> Data where T: ContiguousBytes {
+        var result = [UInt8](repeating: 0, count: Int(CC_SHA384_DIGEST_LENGTH))
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA384(buffer.baseAddress, CC_LONG(buffer.count), &result)
         }
-        return Data(bytes)
+        return Data(result)
     }
 }
 
@@ -386,11 +380,10 @@ public final class SHA512: Digest {
     /// Combines data to be hashed.
     /// Can be called repeatedly with chunks of the message.
     ///
-    /// - Parameters:
-    ///   - data: data to be combined
-    public func combine(_ data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA512_Update(context, buffer.baseAddress, CC_LONG(data.count))
+    /// - Parameters: bytes: Data chunk to digest.
+    public func combine<T>(_ bytes: T) where T: ContiguousBytes {
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA512_Update(context, buffer.baseAddress, CC_LONG(buffer.count))
         }
     }
 
@@ -411,12 +404,12 @@ public final class SHA512: Digest {
     /// $ openssl SHA512 <<< "string_to_be_hashed"
     ///
     /// - Returns: data digest (cryptographic hash) in SHA512.
-    public static func hash(_ data: Data) -> Data {
-        var bytes = [UInt8](repeating: 0, count: Int(CC_SHA512_DIGEST_LENGTH))
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_SHA512(buffer.baseAddress, CC_LONG(buffer.count), &bytes)
+    public static func hash<T>(_ bytes: T) -> Data where T: ContiguousBytes {
+        var result = [UInt8](repeating: 0, count: Int(CC_SHA512_DIGEST_LENGTH))
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_SHA512(buffer.baseAddress, CC_LONG(buffer.count), &result)
         }
-        return Data(bytes)
+        return Data(result)
     }
 }
 

--- a/GoldenKey/CommonCrypto/Digest.swift.gyb
+++ b/GoldenKey/CommonCrypto/Digest.swift.gyb
@@ -11,10 +11,11 @@ import CommonCrypto.CommonDigest
 
 public protocol Digest {
 
-    /// Updates the digest with another data chunk. This can be called multiple times. Use this method for streaming digests.
-    /// - parameters:
-    ///     - data: Data chunk to digest.
-    func combine(_ data: Data)
+    /// Updates the digest with another data chunk. This can be called multiple times.
+    /// Use this method for streaming digests.
+    ///
+    /// - Parameters: bytes: Data chunk to digest.
+    func combine<T>(_ bytes: T) where T: ContiguousBytes
 
     /// Return the digest of the data passed to the `combine(_:)` method so far.
     func finalize() -> Data
@@ -47,11 +48,10 @@ public final class ${name}: Digest {
     /// Combines data to be hashed.
     /// Can be called repeatedly with chunks of the message.
     ///
-    /// - Parameters:
-    ///   - data: data to be combined
-    public func combine(_ data: Data) {
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_${name}_Update(context, buffer.baseAddress, CC_LONG(data.count))
+    /// - Parameters: bytes: Data chunk to digest.
+    public func combine<T>(_ bytes: T) where T: ContiguousBytes {
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_${name}_Update(context, buffer.baseAddress, CC_LONG(buffer.count))
         }
     }
 
@@ -72,12 +72,12 @@ public final class ${name}: Digest {
     /// $ openssl ${name} <<< "string_to_be_hashed"
     ///
     /// - Returns: data digest (cryptographic hash) in ${name}.
-    public static func hash(_ data: Data) -> Data {
-        var bytes = [UInt8](repeating: 0, count: Int(CC_${name}_DIGEST_LENGTH))
-        data.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
-            _ = CC_${name}(buffer.baseAddress, CC_LONG(buffer.count), &bytes)
+    public static func hash<T>(_ bytes: T) -> Data where T: ContiguousBytes {
+        var result = [UInt8](repeating: 0, count: Int(CC_${name}_DIGEST_LENGTH))
+        bytes.withUnsafeBytes { (buffer: UnsafeRawBufferPointer) -> Void in
+            _ = CC_${name}(buffer.baseAddress, CC_LONG(buffer.count), &result)
         }
-        return Data(bytes)
+        return Data(result)
     }
 }
 


### PR DESCRIPTION
`ContiguousBytes` provide interface for work with `UnsafeRawBufferPointer`.

This will make the interface more flexible. 
Parameters can be not only `Data` but all types of `ContiguousBytes` supporting.
https://developer.apple.com/documentation/foundation/contiguousbytes

